### PR TITLE
Use single ticks in Bash alias example

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 depno is distributed as a docker image, so to run it just use the following alias:
 
 ```
-alias depno="docker run --rm -v $PWD:/workdir -w /workdir netanelgilad/depno"
+alias depno='docker run --rm -v $PWD:/workdir -w /workdir netanelgilad/depno'
 ```
 
 <hr />


### PR DESCRIPTION
Having something like
```bash
alias something="echo $PWD"
```
would use `$PWD` of the current execution, because it will be immediately evaluated. Use single ticks to ensure deferred evaluation:
```bash
alias something='echo $PWD'
```